### PR TITLE
atualização para testes

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,4 +6,4 @@ sonar.javascript.file.suffixes=.js,.jsx
 sonar.typescript.file.suffixes=.ts,.tsx 
 sonar.sourceEncoding=UTF-8 
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
-sonar.exclusions=**/__tests__/*.tsx , **/coverage/**/*.js,**/setupTests.ts,**/babel.config.js,**/index.js, **/metro.config.js, **/App.tsx
+sonar.exclusions=**/*.test.*


### PR DESCRIPTION
alteração no filtro de exclusão do sonar para que considere os arquivos que contenham ".teste." em sua nomeclatura sejam ignorados